### PR TITLE
Revert back to mapbox::variant

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,15 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(Catch2)
 
+FetchContent_Declare(
+  MapboxVariant
+  GIT_REPOSITORY https://github.com/mapbox/variant.git
+  GIT_TAG origin/master
+)
+FetchContent_MakeAvailable(MapboxVariant)
+
+include_directories(SYSTEM ${mapboxvariant_SOURCE_DIR}/include)
+
 target_link_libraries(unit-tests PRIVATE Catch2WithMain)
 
 # libbenchmark.a supports threads and therefore needs pthread support

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Creating a geometry collection:
 
 ```cpp
 #include <maplibre/geometry/geometry.hpp>
-#include <variant>
+#include <mapbox/variant.hpp>
 #include <iostream>
 
 using maplibre::geometry::geometry_collection;
@@ -82,6 +82,6 @@ int main() {
     gc.emplace_back(point_type(1.0,0.0));
     geometry<double> const& geom = gc.at(0);
     printer visitor;
-    std::visit(visitor, geom);
+    mapbox::util::apply_visitor(visitor,geom);
 }
 ```

--- a/include/maplibre/feature.hpp
+++ b/include/maplibre/feature.hpp
@@ -2,15 +2,40 @@
 
 #include <maplibre/geometry.hpp>
 
+#include <mapbox/variant.hpp>
+
 #include <cstdint>
 #include <string>
-#include <variant>
 #include <vector>
 #include <memory>
 #include <unordered_map>
 
 namespace maplibre {
 namespace feature {
+
+// comparator functors
+struct equal_comp_shared_ptr
+{
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wfloat-equal"
+    template <typename T>
+    bool operator()(T const& lhs, T const& rhs) const
+    {
+        return lhs == rhs;
+    }
+#pragma GCC diagnostic pop
+
+    template <typename T>
+    bool operator()(std::shared_ptr<T> const& lhs, std::shared_ptr<T> const& rhs) const
+    {
+        if (lhs == rhs)
+        {
+            return true;
+        }
+        return *lhs == *rhs;
+    }
+};
 
 struct value;
 
@@ -24,25 +49,25 @@ constexpr bool operator<(const null_value_t&, const null_value_t&) { return fals
 
 constexpr null_value_t null_value = null_value_t();
 
-// helper class for std::visit
-namespace {
-template <class... Ts>
-struct overloaded : Ts...
-{
-    using Ts::operator()...;
-};
-}; // namespace
-
-struct value;
-
+#define DECLARE_VALUE_TYPE_ACCESOR(NAME, TYPE)        \
+    TYPE* get##NAME() noexcept                        \
+    {                                                 \
+        return match(                                 \
+            [](TYPE& val) -> TYPE* { return &val; },  \
+            [](auto&) -> TYPE* { return nullptr; });  \
+    }                                                 \
+    const TYPE* get##NAME() const noexcept            \
+    {                                                 \
+        return const_cast<value*>(this)->get##NAME(); \
+    }
 // Multiple numeric types (uint64_t, int64_t, double) are present in order to support
 // the widest possible range of JSON numbers, which do not have a maximum range.
 // Implementations that produce `value`s should use that order for type preference,
 // using uint64_t for positive integers, int64_t for negative integers, and double
 // for non-integers and integers outside the range of 64 bits.
-using value_base = std::variant<null_value_t, bool, uint64_t, int64_t, double, std::string,
-                                std::shared_ptr<std::vector<value>>,
-                                std::shared_ptr<std::unordered_map<std::string, value>>>;
+using value_base = mapbox::util::variant<null_value_t, bool, uint64_t, int64_t, double, std::string,
+                                         std::shared_ptr<std::vector<value>>,
+                                         std::shared_ptr<std::unordered_map<std::string, value>>>;
 
 struct value : public value_base
 {
@@ -80,33 +105,31 @@ struct value : public value_base
     value(object_type object) : value_base(std::make_shared<object_type>(std::forward<object_type>(object))) {}
     value(object_ptr_type object) : value_base(object) {}
 
-    bool operator==(const value& rhs) const
+    bool operator==(value const& rhs) const
     {
-        if (index() != rhs.index()) return false;
-
-        if (std::holds_alternative<value::array_ptr_type>(*this))
+        assert(valid() && rhs.valid());
+        if (this->which() != rhs.which())
         {
-            return *std::get<value::array_ptr_type>(*this) == *std::get<value::array_ptr_type>(rhs);
+            return false;
         }
-
-        if (std::holds_alternative<value::object_ptr_type>(*this))
-        {
-            return *std::get<value::object_ptr_type>(*this) == *std::get<value::object_ptr_type>(rhs);
-        }
-
-        return *static_cast<const value_base*>(this) == rhs;
+        mapbox::util::detail::comparer<value, equal_comp_shared_ptr> visitor(*this);
+        return visit(rhs, visitor);
     }
 
-    explicit operator bool() const { return !std::holds_alternative<null_value_t>(variant()); }
+    explicit operator bool() const { return !is<null_value_t>(); }
+
+    DECLARE_VALUE_TYPE_ACCESOR(Int, int64_t)
+    DECLARE_VALUE_TYPE_ACCESOR(Uint, uint64_t)
+    DECLARE_VALUE_TYPE_ACCESOR(Bool, bool)
+    DECLARE_VALUE_TYPE_ACCESOR(Double, double)
+    DECLARE_VALUE_TYPE_ACCESOR(String, std::string)
 
     array_ptr_type getArray() noexcept
     {
-        return std::visit(overloaded{
-                              [](array_ptr_type& val) -> array_ptr_type { return val; },
-                              [](auto&) -> array_ptr_type { return nullptr; }},
-                          variant());
+        return match(
+            [](array_ptr_type& val) -> array_ptr_type { return val; },
+            [](auto&) -> array_ptr_type { return nullptr; });
     }
-
     const_array_ptr_type getArray() const noexcept
     {
         return const_cast<value*>(this)->getArray();
@@ -114,95 +137,22 @@ struct value : public value_base
 
     object_ptr_type getObject() noexcept
     {
-        return std::visit(overloaded{
-                              [](object_ptr_type& val) -> object_ptr_type { return val; },
-                              [](auto&) -> object_ptr_type { return nullptr; }},
-                          variant());
+        return match(
+            [](object_ptr_type& val) -> object_ptr_type { return val; },
+            [](auto&) -> object_ptr_type { return nullptr; });
     }
-
     const_object_ptr_type getObject() const noexcept
     {
         return const_cast<value*>(this)->getObject();
     }
-
-    value_base& variant()
-    {
-        return *static_cast<value_base*>(this);
-    }
-
-    value_base const& variant() const
-    {
-        return *static_cast<const value_base*>(this);
-    }
-
-    int64_t* getInt() noexcept
-    {
-        return std::visit(overloaded{
-                              [](int64_t& val) -> int64_t* { return &val; },
-                              [](auto&) -> int64_t* { return nullptr; }},
-                          variant());
-    }
-
-    const int64_t* getInt() const noexcept
-    {
-        return const_cast<value*>(this)->getInt();
-    }
-
-    uint64_t* getUint() noexcept
-    {
-        return std::visit(overloaded{
-                              [](uint64_t& val) -> uint64_t* { return &val; },
-                              [](auto&) -> uint64_t* { return nullptr; }},
-                          variant());
-    }
-
-    const uint64_t* getUint() const noexcept
-    {
-        return const_cast<value*>(this)->getUint();
-    }
-
-    bool* getBool() noexcept
-    {
-        return std::visit(overloaded{
-                              [](bool& val) -> bool* { return &val; },
-                              [](auto&) -> bool* { return nullptr; }},
-                          variant());
-    }
-
-    const bool* getBool() const noexcept
-    {
-        return const_cast<value*>(this)->getBool();
-    }
-    double* getDouble() noexcept
-    {
-        return std::visit(overloaded{
-                              [](double& val) -> double* { return &val; },
-                              [](auto&) -> double* { return nullptr; }},
-                          variant());
-    }
-
-    const double* getDouble() const noexcept
-    {
-        return const_cast<value*>(this)->getDouble();
-    }
-    std::string* getString() noexcept
-    {
-        return std::visit(overloaded{
-                              [](std::string& val) -> std::string* { return &val; },
-                              [](auto&) -> std::string* { return nullptr; }},
-                          variant());
-    }
-
-    const std::string* getString() const noexcept
-    {
-        return const_cast<value*>(this)->getString();
-    }
 };
+
+#undef DECLARE_VALUE_TYPE_ACCESOR
 
 using property_map = value::object_type;
 
 // The same considerations and requirement for numeric types apply as for `value_base`.
-using identifier = std::variant<null_value_t, uint64_t, int64_t, double, std::string>;
+using identifier = mapbox::util::variant<null_value_t, uint64_t, int64_t, double, std::string>;
 
 template <class T>
 struct feature

--- a/include/maplibre/geometry/for_each_point.hpp
+++ b/include/maplibre/geometry/for_each_point.hpp
@@ -22,21 +22,19 @@ auto for_each_point(Container&& container, F&& f)
     -> decltype(container.begin(), container.end(), void());
 
 template <typename... Types, typename F>
-void for_each_point(std::variant<Types...> const& geom, F&& f)
+void for_each_point(mapbox::util::variant<Types...> const& geom, F&& f)
 {
-    std::visit([&](auto const& g) {
+    mapbox::util::variant<Types...>::visit(geom, [&](auto const& g) {
         for_each_point(g, f);
-    },
-               geom);
+    });
 }
 
 template <typename... Types, typename F>
-void for_each_point(std::variant<Types...>& geom, F&& f)
+void for_each_point(mapbox::util::variant<Types...>& geom, F&& f)
 {
-    std::visit([&](auto& g) {
+    mapbox::util::variant<Types...>::visit(geom, [&](auto& g) {
         for_each_point(g, f);
-    },
-               geom);
+    });
 }
 
 template <typename Container, typename F>

--- a/include/maplibre/geometry/geometry.hpp
+++ b/include/maplibre/geometry/geometry.hpp
@@ -8,8 +8,9 @@
 #include <maplibre/geometry/multi_line_string.hpp>
 #include <maplibre/geometry/multi_polygon.hpp>
 
+#include <mapbox/variant.hpp>
+
 // stl
-#include <variant>
 #include <vector>
 
 namespace maplibre {
@@ -19,14 +20,14 @@ template <typename T, template <typename...> class Cont = std::vector>
 struct geometry_collection;
 
 template <typename T, template <typename...> class Cont = std::vector>
-using geometry_base = std::variant<empty,
-                                   point<T>,
-                                   line_string<T, Cont>,
-                                   polygon<T, Cont>,
-                                   multi_point<T, Cont>,
-                                   multi_line_string<T, Cont>,
-                                   multi_polygon<T, Cont>,
-                                   geometry_collection<T, Cont>>;
+using geometry_base = mapbox::util::variant<empty,
+                                            point<T>,
+                                            line_string<T, Cont>,
+                                            polygon<T, Cont>,
+                                            multi_point<T, Cont>,
+                                            multi_line_string<T, Cont>,
+                                            multi_polygon<T, Cont>,
+                                            geometry_collection<T, Cont>>;
 
 template <typename T, template <typename...> class Cont = std::vector>
 struct geometry : geometry_base<T, Cont>

--- a/include/maplibre/geometry/multi_line_string.hpp
+++ b/include/maplibre/geometry/multi_line_string.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <maplibre/geometry/line_string.hpp>
-
 #include <vector>
 
 namespace maplibre {

--- a/include/maplibre/geometry_io.hpp
+++ b/include/maplibre/geometry_io.hpp
@@ -76,7 +76,7 @@ std::ostream& operator<<(std::ostream& os, const multi_polygon<T>& geom)
 template <typename T>
 std::ostream& operator<<(std::ostream& os, const geometry<T>& geom)
 {
-    std::visit([&](const auto& g) { os << g; }, geom);
+    geometry<T>::visit(geom, [&](const auto& g) { os << g; });
     return os;
 }
 
@@ -148,7 +148,7 @@ struct value_to_stream_visitor
             {
                 out << ',';
             }
-            std::visit(*this, item);
+            mapbox::util::apply_visitor(*this, item);
         }
         out << ']';
     }
@@ -181,7 +181,7 @@ struct value_to_stream_visitor
             auto const val = map.find(k);
             quote_string(k, out);
             out << ':';
-            std::visit(*this, val->second);
+            mapbox::util::apply_visitor(*this, val->second);
         }
         out << '}';
     }
@@ -208,7 +208,7 @@ inline std::ostream& operator<<(std::ostream& os, std::vector<maplibre::feature:
 
 inline std::ostream& operator<<(std::ostream& os, maplibre::feature::value const& val)
 {
-    std::visit(value_to_stream_visitor{os}, val);
+    mapbox::util::apply_visitor(value_to_stream_visitor{os}, val);
     return os;
 }
 
@@ -231,7 +231,7 @@ struct identifier_to_stream_visitor
 
 inline std::ostream& operator<<(std::ostream& os, maplibre::feature::identifier const& val)
 {
-    std::visit(identifier_to_stream_visitor{os}, val);
+    mapbox::util::apply_visitor(identifier_to_stream_visitor{os}, val);
     return os;
 }
 

--- a/test/feature.cpp
+++ b/test/feature.cpp
@@ -17,8 +17,8 @@ try
 {
     value v{arg};
     CHECK(v);
-    CHECK(std::holds_alternative<T>(v));
-    CHECK(std::get<T>(v) == arg);
+    CHECK(v.template is<T>());
+    CHECK(v.template get<T>() == arg);
 }
 catch (...)
 {
@@ -31,8 +31,8 @@ try
 {
     value v{arg};
     CHECK(v);
-    CHECK(std::holds_alternative<T>(v));
-    CHECK(*(std::get<T>(v)) == *arg);
+    CHECK(v.template is<T>());
+    CHECK(*(v.template get<T>()) == *arg);
 }
 catch (...)
 {
@@ -45,8 +45,8 @@ try
 {
     value v{arg};
     CHECK(v);
-    CHECK(std::holds_alternative<T>(v));
-    CHECK(*(std::get<T>(v)) == arg);
+    CHECK(v.template is<T>());
+    CHECK(*(v.template get<T>()) == arg);
 }
 catch (...)
 {
@@ -73,13 +73,13 @@ TEST_CASE("test value")
     checkPtrType2<value::object_ptr_type>(map);
 
     value intV{32};
-    CHECK_THROWS(std::get<uint64_t>(intV));
+    CHECK_THROWS(intV.get<uint64_t>());
 
     auto* result = intV.getInt();
     CHECK(result);
     CHECK(*result == 32);
     *result = 100;
-    CHECK(std::get<int64_t>(intV) == 100);
+    CHECK(intV.get<int64_t>() == 100);
 
     CHECK_FALSE(intV.getUint());
     CHECK_FALSE(intV.getBool());
@@ -111,7 +111,7 @@ TEST_CASE("test value operator==")
 TEST_CASE("test feature")
 {
     feature<int64_t> pf{point<int64_t>()};
-    CHECK(std::holds_alternative<point<int64_t>>(pf.geometry));
+    CHECK(pf.geometry.is<point<int64_t>>());
     CHECK(pf.properties.empty());
 
     auto& p = pf.properties;
@@ -123,22 +123,21 @@ TEST_CASE("test feature")
     p["int"] = int64_t(-10);
     p["null"] = null_value;
 
-    REQUIRE(std::holds_alternative<bool>(p["bool"]));
+    REQUIRE(p["bool"].is<bool>());
     CHECK(p["bool"] == true);
-    REQUIRE(std::holds_alternative<std::string>(p["string"]));
+    REQUIRE(p["string"].is<std::string>());
     CHECK(p["string"] == std::string("foo"));
-    REQUIRE(std::holds_alternative<double>(p["double"]));
+    REQUIRE(p["double"].is<double>());
     CHECK(p["double"] == 2.5);
-    REQUIRE(std::holds_alternative<uint64_t>(p["uint"]));
+    REQUIRE(p["uint"].is<uint64_t>());
     CHECK(p["uint"] == uint64_t(10));
-    REQUIRE(std::holds_alternative<int64_t>(p["int"]));
+    REQUIRE(p["int"].is<int64_t>());
     CHECK(p["int"] == int64_t(-10));
-    REQUIRE(std::holds_alternative<null_value_t>(p["null"]));
+    REQUIRE(p["null"].is<null_value_t>());
     CHECK(p["null"] == null_value);
 
     p["null"] = null_value_t{};
-    REQUIRE(std::holds_alternative<null_value_t>(p["null"]));
-
+    REQUIRE(p["null"].is<null_value_t>());
     CHECK(p["null"] == null_value);
 
     CHECK(p == p);

--- a/test/for_each_point.cpp
+++ b/test/for_each_point.cpp
@@ -47,7 +47,7 @@ TEST_CASE("test for each point")
     CHECK(g == geometry<int64_t>(polygon<int64_t>({{{0, -1}, {-2, -3}}})));
 
     // Custom geometry type
-    using my_geometry = std::variant<point<int64_t>>;
+    using my_geometry = mapbox::util::variant<point<int64_t>>;
     CHECK(count_points(my_geometry(point<int64_t>())) == 1);
 
     // Custom point type
@@ -57,5 +57,5 @@ TEST_CASE("test for each point")
         int16_t y;
     };
     CHECK(count_points(std::vector<my_point>({my_point{0, 1}})) == 1);
-    CHECK(count_points(std::variant<my_point>(my_point{0, 1})) == 1);
+    CHECK(count_points(mapbox::util::variant<my_point>(my_point{0, 1})) == 1);
 }

--- a/test/geometry.cpp
+++ b/test/geometry.cpp
@@ -14,11 +14,11 @@ using maplibre::geometry::polygon;
 TEST_CASE("test empty in geometry")
 {
     geometry<int64_t> g0;
-    CHECK(std::holds_alternative<empty>(g0));
+    CHECK(g0.is<empty>());
 
     empty n1;
     geometry<int64_t> g1(n1);
-    CHECK(std::holds_alternative<empty>(g1));
+    CHECK(g1.is<empty>());
 
     CHECK(g0 == g1);
 }
@@ -27,10 +27,10 @@ TEST_CASE("test point in geometry")
 {
     point<int64_t> p1(1, 2);
     geometry<int64_t> g1(p1);
-    CHECK(std::holds_alternative<point<int64_t>>(g1));
+    CHECK(g1.is<point<int64_t>>());
 
     geometry<int64_t> g2(p1);
-    CHECK(std::holds_alternative<point<int64_t>>(g2));
+    CHECK(g2.is<point<int64_t>>());
 
     CHECK(g1 == g2);
 }
@@ -41,10 +41,10 @@ TEST_CASE("test multi point in geometry")
     mp1.emplace_back(1, 2);
 
     geometry<int64_t> g1(mp1);
-    CHECK(std::holds_alternative<multi_point<int64_t>>(g1));
+    CHECK(g1.is<multi_point<int64_t>>());
 
     geometry<int64_t> g2(mp1);
-    CHECK(std::holds_alternative<multi_point<int64_t>>(g2));
+    CHECK(g2.is<multi_point<int64_t>>());
 
     CHECK(g1 == g2);
 }
@@ -56,10 +56,10 @@ TEST_CASE("test line string in geometry")
     ls1.emplace_back(3, 4);
 
     geometry<int64_t> g1(ls1);
-    CHECK(std::holds_alternative<line_string<int64_t>>(g1));
+    CHECK(g1.is<line_string<int64_t>>());
 
     geometry<int64_t> g2(ls1);
-    CHECK(std::holds_alternative<line_string<int64_t>>(g2));
+    CHECK(g2.is<line_string<int64_t>>());
 
     CHECK(g1 == g2);
 }
@@ -69,10 +69,10 @@ TEST_CASE("test multi line string in geometry")
     multi_line_string<int64_t> mls1 = {{{1, 2}, {3, 4}}, {{5, 6}, {7, 8}}};
 
     geometry<int64_t> g1(mls1);
-    CHECK(std::holds_alternative<multi_line_string<int64_t>>(g1));
+    CHECK(g1.is<multi_line_string<int64_t>>());
 
     geometry<int64_t> g2(mls1);
-    CHECK(std::holds_alternative<multi_line_string<int64_t>>(g2));
+    CHECK(g2.is<multi_line_string<int64_t>>());
 
     CHECK(g1 == g2);
 }
@@ -82,10 +82,10 @@ TEST_CASE("test polygon in geometry")
     polygon<int64_t> poly1 = {{{1, 2}, {3, 4}}, {{5, 6}, {7, 8}}};
 
     geometry<int64_t> g1(poly1);
-    CHECK(std::holds_alternative<polygon<int64_t>>(g1));
+    CHECK(g1.is<polygon<int64_t>>());
 
     geometry<int64_t> g2(poly1);
-    CHECK(std::holds_alternative<polygon<int64_t>>(g2));
+    CHECK(g2.is<polygon<int64_t>>());
 
     CHECK(g1 == g2);
 }
@@ -95,10 +95,10 @@ TEST_CASE("test multi polygon in geometry")
     multi_polygon<int64_t> mp1 = {{{{1, 2}, {3, 4}}, {{5, 6}, {7, 8}}}};
 
     geometry<int64_t> g1(mp1);
-    CHECK(std::holds_alternative<multi_polygon<int64_t>>(g1));
+    CHECK(g1.is<multi_polygon<int64_t>>());
 
     geometry<int64_t> g2(mp1);
-    CHECK(std::holds_alternative<multi_polygon<int64_t>>(g2));
+    CHECK(g2.is<multi_polygon<int64_t>>());
 
     CHECK(g1 == g2);
 }
@@ -106,28 +106,28 @@ TEST_CASE("test multi polygon in geometry")
 TEST_CASE("test geometry")
 {
     geometry<int64_t> eg; // default constructed geometry is empty
-    CHECK(std::holds_alternative<empty>(eg));
+    CHECK(eg.is<empty>());
 
     geometry<int64_t> pg{point<int64_t>()};
-    CHECK(std::holds_alternative<point<int64_t>>(pg));
+    CHECK(pg.is<point<int64_t>>());
 
     geometry<int64_t> lsg{line_string<int64_t>()};
-    CHECK(std::holds_alternative<line_string<int64_t>>(lsg));
+    CHECK(lsg.is<line_string<int64_t>>());
 
     geometry<int64_t> pgg{polygon<int64_t>()};
-    CHECK(std::holds_alternative<polygon<int64_t>>(pgg));
+    CHECK(pgg.is<polygon<int64_t>>());
 
     geometry<int64_t> mpg{multi_point<int64_t>()};
-    CHECK(std::holds_alternative<multi_point<int64_t>>(mpg));
+    CHECK(mpg.is<multi_point<int64_t>>());
 
     geometry<int64_t> mlsg{multi_line_string<int64_t>()};
-    CHECK(std::holds_alternative<multi_line_string<int64_t>>(mlsg));
+    CHECK(mlsg.is<multi_line_string<int64_t>>());
 
     geometry<int64_t> mpgg{multi_polygon<int64_t>()};
-    CHECK(std::holds_alternative<multi_polygon<int64_t>>(mpgg));
+    CHECK(mpgg.is<multi_polygon<int64_t>>());
 
     geometry<int64_t> gcg{geometry_collection<int64_t>()};
-    CHECK(std::holds_alternative<geometry_collection<int64_t>>(gcg));
+    CHECK(gcg.is<geometry_collection<int64_t>>());
 
     CHECK(pg == pg);
     CHECK(!(pg != pg));


### PR DESCRIPTION
Undoes most of the changes in #1 since `std::variant` is hopelessly bloated.